### PR TITLE
Fix getcategory DCS 2.9.1.48111

### DIFF
--- a/skynet-iads-source/skynet-iads-contact.lua
+++ b/skynet-iads-source/skynet-iads-contact.lua
@@ -71,8 +71,10 @@ function SkynetIADSContact:getTypeName()
 	if self:isIdentifiedAsHARM() then
 		return SkynetIADSContact.HARM
 	end
-	local category = self:getDCSRepresentation():getCategory()
+	local category = Object.getCategory(self:getDCSRepresentation()) -- getCategory changed in DCS 2.9.1.48111 see https://forum.dcs.world/topic/337957-patch-notes-discussion-november-2023/#comment-5330539
 	if category == Object.Category.UNIT then
+		return self.typeName
+	elseif category == Object.Category.WEAPON then
 		return self.typeName
 	end
 	return "UNKNOWN"


### PR DESCRIPTION
Accounting for the `getCategory` changed in DCS 2.9.1.48111 see https://forum.dcs.world/topic/337957-patch-notes-discussion-november-2023/#comment-5330539

Also added the display of the type of weapon contacts.