### PR TITLE
Fix: getCategory

### DIFF
--- a/skynet-iads-source/skynet-iads-contact.lua
+++ b/skynet-iads-source/skynet-iads-contact.lua
@@ -71,12 +71,15 @@ function SkynetIADSContact:getTypeName()
 	if self:isIdentifiedAsHARM() then
 		return SkynetIADSContact.HARM
 	end
+
+	-- self:getDCSRepresentation():getCategory() will fail with an error if self:getDCSRepresentation() is not nil but the unit is destroyed. The error will obviously interrupt the treatment that called getTypeName(), with consequences I did not try to track.
+	-- Using Object.getCategory instead will get us nil in that case.
 	if self:getDCSRepresentation() ~= nil then
-		local category = self:getDCSRepresentation():getCategory()
+		local category = Object.getCategory(self:getDCSRepresentation())
 		if category == Object.Category.UNIT then
 			return self.typeName
 		end
-	end
+	end 
 	return "UNKNOWN"
 end
 


### PR DESCRIPTION
https://github.com/walder/Skynet-IADS/pull/92 was proposed to account for a change in DCS 2.9.1.48111 ( https://forum.dcs.world/topic/337957-patch-notes-discussion-november-2023/#comment-5330539 ).
This change was later announced as reverted by ED and thus the PR was thought not to be required anymore.

As it turns out, testing showed that even with the ED revert, `getCategory `was not working as before and so the modification is still needed.

This PR is the same thing - minus the "WEAPON" part.